### PR TITLE
Fix style fallback text encoding issue

### DIFF
--- a/bot/cogs/commands.py
+++ b/bot/cogs/commands.py
@@ -230,7 +230,11 @@ class Commands(commands.Cog):
             """
 
             # スタイルが指定されている場合のテキスト
-            style_text = f"スタイル: {style}風でお願いします。" if style else "特に指定���しのスタイルでお願いします。"
+            style_text = (
+                f"スタイル: {style}風でお願いします。"
+                if style
+                else "特に指定なしのスタイルでお願いします。"
+            )
 
             # 単語リストのフォーマット（選択された単語のみ）
             word_list = ""


### PR DESCRIPTION
## Summary
- fix encoding issue with fallback style text in `bunshou` command

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d446ef4588331b29cef05001b5497